### PR TITLE
Add commands in PointPoolCommands

### DIFF
--- a/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
@@ -18,12 +18,14 @@ package org.terasology.PointPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.PointPool.event.DrainPoolEvent;
+import org.terasology.PointPool.event.InstantDrainEvent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.PointPool.event.FillPoolEvent;
+import org.terasology.protobuf.EntityData;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class PointPoolAuthoritySystem extends BaseComponentSystem {
@@ -52,7 +54,12 @@ public class PointPoolAuthoritySystem extends BaseComponentSystem {
         logger.info("Current status " + pointPoolComponent.poolValue);
     }
 
-    private void instantDrain() {
+    @ReceiveEvent(components = {PointPoolComponent.class})
+    public void instantDrain(InstantDrainEvent event, EntityRef entity) {
+        PointPoolComponent pointPoolComponent = entity.getComponent(PointPoolComponent.class);
+        pointPoolComponent.poolValue = 0;
+        entity.saveComponent(pointPoolComponent);
+        logger.info("Current status " + pointPoolComponent.poolValue);
     }
 
     private void instantFill() {

--- a/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
@@ -30,7 +30,7 @@ public class PointPoolAuthoritySystem extends BaseComponentSystem {
     private static final Logger logger = LoggerFactory.getLogger(PointPoolAuthoritySystem.class);
 
     @ReceiveEvent(components = {PointPoolComponent.class})
-    private void onFillPool(FillPoolEvent event, EntityRef entity) {
+    public void onFillPool(FillPoolEvent event, EntityRef entity) {
         PointPoolComponent poolComponent = entity.getComponent(PointPoolComponent.class);
         poolComponent.poolValue += event.getValue();
         if (poolComponent.poolValue > poolComponent.maxPoolValue) {

--- a/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
@@ -29,14 +29,15 @@ public class PointPoolAuthoritySystem extends BaseComponentSystem {
 
     private static final Logger logger = LoggerFactory.getLogger(PointPoolAuthoritySystem.class);
 
-    @ReceiveEvent
-    private void fillPool(FillPoolEvent event, PointPoolComponent poolComponent) {
+    @ReceiveEvent(components = {PointPoolComponent.class})
+    private void onFillPool(FillPoolEvent event, EntityRef entity) {
+        PointPoolComponent poolComponent = entity.getComponent(PointPoolComponent.class);
         poolComponent.poolValue += event.getValue();
         if (poolComponent.poolValue > poolComponent.maxPoolValue) {
             poolComponent.poolValue = poolComponent.maxPoolValue;
         }
         event.getInstigator().saveComponent(poolComponent);
-        logger.info("Current status "+poolComponent.poolValue);
+        logger.info("Current status " + poolComponent.poolValue);
     }
 
     private void drainPool() {

--- a/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.PointPool.event.DrainPoolEvent;
 import org.terasology.PointPool.event.InstantDrainEvent;
+import org.terasology.PointPool.event.InstantFillEvent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
@@ -62,7 +63,12 @@ public class PointPoolAuthoritySystem extends BaseComponentSystem {
         logger.info("Current status " + pointPoolComponent.poolValue);
     }
 
-    private void instantFill() {
+    @ReceiveEvent(components = {PointPoolComponent.class})
+    public void instantFill(InstantFillEvent event, EntityRef entity) {
+        PointPoolComponent pointPoolComponent = entity.getComponent(PointPoolComponent.class);
+        pointPoolComponent.poolValue = pointPoolComponent.maxPoolValue;
+        entity.saveComponent(pointPoolComponent);
+        logger.info("Current status " + pointPoolComponent.poolValue);
     }
 
     private float getStatus() {

--- a/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
@@ -26,16 +26,14 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.PointPool.event.FillPoolEvent;
-import org.terasology.protobuf.EntityData;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class PointPoolAuthoritySystem extends BaseComponentSystem {
 
     private static final Logger logger = LoggerFactory.getLogger(PointPoolAuthoritySystem.class);
 
-    @ReceiveEvent(components = {PointPoolComponent.class})
-    public void onFillPool(FillPoolEvent event, EntityRef entity) {
-        PointPoolComponent poolComponent = entity.getComponent(PointPoolComponent.class);
+    @ReceiveEvent
+    public void onFillPool(FillPoolEvent event, EntityRef entity, PointPoolComponent poolComponent) {
         poolComponent.poolValue += event.getValue();
         if (poolComponent.poolValue > poolComponent.maxPoolValue) {
             poolComponent.poolValue = poolComponent.maxPoolValue;
@@ -44,9 +42,8 @@ public class PointPoolAuthoritySystem extends BaseComponentSystem {
         logger.info("Current status " + poolComponent.poolValue);
     }
 
-    @ReceiveEvent(components = {PointPoolComponent.class})
-    public void drainPool(DrainPoolEvent event, EntityRef entity) {
-        PointPoolComponent pointPoolComponent = entity.getComponent(PointPoolComponent.class);
+    @ReceiveEvent
+    public void drainPool(DrainPoolEvent event, EntityRef entity, PointPoolComponent pointPoolComponent) {
         pointPoolComponent.poolValue -= event.getValue();
         if (pointPoolComponent.poolValue < 0) {
             pointPoolComponent.poolValue = 0;
@@ -55,17 +52,15 @@ public class PointPoolAuthoritySystem extends BaseComponentSystem {
         logger.info("Current status " + pointPoolComponent.poolValue);
     }
 
-    @ReceiveEvent(components = {PointPoolComponent.class})
-    public void instantDrain(InstantDrainEvent event, EntityRef entity) {
-        PointPoolComponent pointPoolComponent = entity.getComponent(PointPoolComponent.class);
+    @ReceiveEvent
+    public void instantDrain(InstantDrainEvent event, EntityRef entity, PointPoolComponent pointPoolComponent) {
         pointPoolComponent.poolValue = 0;
         entity.saveComponent(pointPoolComponent);
         logger.info("Current status " + pointPoolComponent.poolValue);
     }
 
-    @ReceiveEvent(components = {PointPoolComponent.class})
-    public void instantFill(InstantFillEvent event, EntityRef entity) {
-        PointPoolComponent pointPoolComponent = entity.getComponent(PointPoolComponent.class);
+    @ReceiveEvent
+    public void instantFill(InstantFillEvent event, EntityRef entity, PointPoolComponent pointPoolComponent) {
         pointPoolComponent.poolValue = pointPoolComponent.maxPoolValue;
         entity.saveComponent(pointPoolComponent);
         logger.info("Current status " + pointPoolComponent.poolValue);

--- a/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
@@ -71,8 +71,4 @@ public class PointPoolAuthoritySystem extends BaseComponentSystem {
         logger.info("Current status " + pointPoolComponent.poolValue);
     }
 
-    private float getStatus() {
-        return 0;
-    }
-
 }

--- a/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolAuthoritySystem.java
@@ -17,6 +17,7 @@ package org.terasology.PointPool;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.PointPool.event.DrainPoolEvent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
@@ -40,7 +41,15 @@ public class PointPoolAuthoritySystem extends BaseComponentSystem {
         logger.info("Current status " + poolComponent.poolValue);
     }
 
-    private void drainPool() {
+    @ReceiveEvent(components = {PointPoolComponent.class})
+    public void drainPool(DrainPoolEvent event, EntityRef entity) {
+        PointPoolComponent pointPoolComponent = entity.getComponent(PointPoolComponent.class);
+        pointPoolComponent.poolValue -= event.getValue();
+        if (pointPoolComponent.poolValue < 0) {
+            pointPoolComponent.poolValue = 0;
+        }
+        entity.saveComponent(pointPoolComponent);
+        logger.info("Current status " + pointPoolComponent.poolValue);
     }
 
     private void instantDrain() {

--- a/src/main/java/org/terasology/PointPool/PointPoolCommands.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolCommands.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.PointPool;
 
+import org.terasology.PointPool.event.DrainPoolEvent;
 import org.terasology.PointPool.event.FillPoolEvent;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -32,7 +33,7 @@ import org.terasology.registry.Share;
 @Share(PointPoolCommands.class)
 public class PointPoolCommands extends BaseComponentSystem {
 
-    @Command(value = "fill", shortDescription = "Fill pool by amount given",
+    @Command(value = "fillPool", shortDescription = "Fill pool by amount given",
             requiredPermission = PermissionManager.NO_PERMISSION)
     public String fill(@Sender EntityRef client, @CommandParam("amount") float amount) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
@@ -40,6 +41,14 @@ public class PointPoolCommands extends BaseComponentSystem {
         clientComp.character.send(new FillPoolEvent(amount, clientComp.character));
 
         return "Pool filled by " + amount;
+    }
+
+    @Command(value = "drainPool", shortDescription = "Drain pool by amount given",
+            requiredPermission = PermissionManager.NO_PERMISSION)
+    public String drainPool(@Sender EntityRef client, @CommandParam("amount") float amount) {
+        ClientComponent clientComp = client.getComponent(ClientComponent.class);
+        clientComp.character.send(new DrainPoolEvent(amount, clientComp.character));
+        return "Pool drained by " + amount;
     }
 
     @Command(value = "listComponents", shortDescription = "Lists all components of character",

--- a/src/main/java/org/terasology/PointPool/PointPoolCommands.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolCommands.java
@@ -18,6 +18,7 @@ package org.terasology.PointPool;
 import org.terasology.PointPool.event.DrainPoolEvent;
 import org.terasology.PointPool.event.FillPoolEvent;
 import org.terasology.PointPool.event.InstantDrainEvent;
+import org.terasology.PointPool.event.InstantFillEvent;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
@@ -58,6 +59,14 @@ public class PointPoolCommands extends BaseComponentSystem {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         clientComp.character.send(new InstantDrainEvent(type, clientComp.character));
         return type + " Pool drained completely";
+    }
+
+    @Command(value = "instantFill", shortDescription = "Instantly fills the given pool",
+            requiredPermission = PermissionManager.NO_PERMISSION)
+    public String instantFill(@Sender EntityRef client, @CommandParam("type") String type) {
+        ClientComponent clientComp = client.getComponent(ClientComponent.class);
+        clientComp.character.send(new InstantFillEvent(type, clientComp.character));
+        return type + " Pool filled completely";
     }
 
     @Command(value = "listComponents", shortDescription = "Lists all components of character",

--- a/src/main/java/org/terasology/PointPool/PointPoolCommands.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolCommands.java
@@ -37,7 +37,7 @@ public class PointPoolCommands extends BaseComponentSystem {
 
     @Command(value = "fillPool", shortDescription = "Fill pool by amount given",
             requiredPermission = PermissionManager.NO_PERMISSION)
-    public String fill(@Sender EntityRef client, @CommandParam("amount") float amount) {
+    public String fill(@Sender EntityRef client, @CommandParam("amount") int amount) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
 
         clientComp.character.send(new FillPoolEvent(amount, clientComp.character));
@@ -47,7 +47,7 @@ public class PointPoolCommands extends BaseComponentSystem {
 
     @Command(value = "drainPool", shortDescription = "Drain pool by amount given",
             requiredPermission = PermissionManager.NO_PERMISSION)
-    public String drainPool(@Sender EntityRef client, @CommandParam("amount") float amount) {
+    public String drainPool(@Sender EntityRef client, @CommandParam("amount") int amount) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         clientComp.character.send(new DrainPoolEvent(amount, clientComp.character));
         return "Pool drained by " + amount;
@@ -86,7 +86,7 @@ public class PointPoolCommands extends BaseComponentSystem {
         // TODO : Make this work for multiple pools attached to same entity
         // for(PointPoolComponent component : clientComp.character.getComponent(PointPoolComponent.class)
         try {
-            float value = clientComp.character.getComponent(PointPoolComponent.class).poolValue;
+            int value = clientComp.character.getComponent(PointPoolComponent.class).poolValue;
             return "Current pool value is " + value;
         } catch (NullPointerException n) {
             return "NullPointerException encountered";

--- a/src/main/java/org/terasology/PointPool/PointPoolCommands.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolCommands.java
@@ -17,6 +17,7 @@ package org.terasology.PointPool;
 
 import org.terasology.PointPool.event.DrainPoolEvent;
 import org.terasology.PointPool.event.FillPoolEvent;
+import org.terasology.PointPool.event.InstantDrainEvent;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
@@ -49,6 +50,14 @@ public class PointPoolCommands extends BaseComponentSystem {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         clientComp.character.send(new DrainPoolEvent(amount, clientComp.character));
         return "Pool drained by " + amount;
+    }
+
+    @Command(value = "instantDrain", shortDescription = "Instantly drain the given pool",
+            requiredPermission = PermissionManager.NO_PERMISSION)
+    public String instantDrain(@Sender EntityRef client, @CommandParam("type") String type) {
+        ClientComponent clientComp = client.getComponent(ClientComponent.class);
+        clientComp.character.send(new InstantDrainEvent(type, clientComp.character));
+        return type + " Pool drained completely";
     }
 
     @Command(value = "listComponents", shortDescription = "Lists all components of character",

--- a/src/main/java/org/terasology/PointPool/PointPoolCommands.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolCommands.java
@@ -19,6 +19,7 @@ import org.terasology.PointPool.event.FillPoolEvent;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
@@ -27,14 +28,15 @@ import org.terasology.logic.permission.PermissionManager;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.Share;
 
-@RegisterSystem
+@RegisterSystem(RegisterMode.AUTHORITY)
 @Share(PointPoolCommands.class)
 public class PointPoolCommands extends BaseComponentSystem {
 
-    @Command(value = "fill", shortDescription = "Fill pool by amount given", runOnServer = true,
+    @Command(value = "fill", shortDescription = "Fill pool by amount given",
             requiredPermission = PermissionManager.NO_PERMISSION)
     public String fill(@Sender EntityRef client, @CommandParam("amount") float amount) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
+
         clientComp.character.send(new FillPoolEvent(amount, clientComp.character));
 
         return "Pool filled by " + amount;

--- a/src/main/java/org/terasology/PointPool/PointPoolComponent.java
+++ b/src/main/java/org/terasology/PointPool/PointPoolComponent.java
@@ -21,11 +21,11 @@ import org.terasology.network.Replicate;
 public class PointPoolComponent implements Component {
 
     @Replicate
-    public float poolValue = 100;
+    public int poolValue = 100;
 
     /* Defines the maximum value possible for the pool */
     @Replicate
-    public float maxPoolValue = 100;
+    public int maxPoolValue = 100;
 
     @Replicate
     public String poolType = "";
@@ -33,7 +33,7 @@ public class PointPoolComponent implements Component {
     public PointPoolComponent() {
     }
 
-    public PointPoolComponent(float poolValue, float maxPoolValue, String poolType) {
+    public PointPoolComponent(int poolValue, int maxPoolValue, String poolType) {
         this.poolValue = poolValue;
         this.maxPoolValue = maxPoolValue;
         this.poolType = poolType;

--- a/src/main/java/org/terasology/PointPool/event/DrainPoolEvent.java
+++ b/src/main/java/org/terasology/PointPool/event/DrainPoolEvent.java
@@ -18,6 +18,9 @@ package org.terasology.PointPool.event;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
 
+/**
+ * Event sent to drain pool by given value
+ */
 public class DrainPoolEvent implements Event {
 
     private int value;

--- a/src/main/java/org/terasology/PointPool/event/DrainPoolEvent.java
+++ b/src/main/java/org/terasology/PointPool/event/DrainPoolEvent.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.PointPool.event;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+
+public class DrainPoolEvent implements Event {
+
+    private float value;
+    private EntityRef instigator;
+
+    public DrainPoolEvent(float value) {
+        this(value, EntityRef.NULL);
+    }
+
+    public DrainPoolEvent(float value, EntityRef instigator) {
+        this.value = value;
+        this.instigator = instigator;
+    }
+
+    public float getValue() {
+        return value;
+    }
+
+    public EntityRef getInstigator() {
+        return instigator;
+    }
+}

--- a/src/main/java/org/terasology/PointPool/event/DrainPoolEvent.java
+++ b/src/main/java/org/terasology/PointPool/event/DrainPoolEvent.java
@@ -20,19 +20,19 @@ import org.terasology.entitySystem.event.Event;
 
 public class DrainPoolEvent implements Event {
 
-    private float value;
+    private int value;
     private EntityRef instigator;
 
-    public DrainPoolEvent(float value) {
+    public DrainPoolEvent(int value) {
         this(value, EntityRef.NULL);
     }
 
-    public DrainPoolEvent(float value, EntityRef instigator) {
+    public DrainPoolEvent(int value, EntityRef instigator) {
         this.value = value;
         this.instigator = instigator;
     }
 
-    public float getValue() {
+    public int getValue() {
         return value;
     }
 

--- a/src/main/java/org/terasology/PointPool/event/FillPoolEvent.java
+++ b/src/main/java/org/terasology/PointPool/event/FillPoolEvent.java
@@ -18,6 +18,9 @@ package org.terasology.PointPool.event;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
 
+/**
+ * Event sent to fill pool by given value
+ */
 public class FillPoolEvent implements Event {
 
     private int value;

--- a/src/main/java/org/terasology/PointPool/event/FillPoolEvent.java
+++ b/src/main/java/org/terasology/PointPool/event/FillPoolEvent.java
@@ -20,19 +20,19 @@ import org.terasology.entitySystem.event.Event;
 
 public class FillPoolEvent implements Event {
 
-    private float value;
+    private int value;
     private EntityRef instigator;
 
-    public FillPoolEvent(float value) {
+    public FillPoolEvent(int value) {
         this(value, EntityRef.NULL);
     }
 
-    public FillPoolEvent(float value, EntityRef instigator) {
+    public FillPoolEvent(int value, EntityRef instigator) {
         this.value = value;
         this.instigator = instigator;
     }
 
-    public float getValue() {
+    public int getValue() {
         return value;
     }
 

--- a/src/main/java/org/terasology/PointPool/event/InstantDrainEvent.java
+++ b/src/main/java/org/terasology/PointPool/event/InstantDrainEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.PointPool.event;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+
+public class InstantDrainEvent implements Event {
+
+    String poolType = "";
+    private EntityRef instigator;
+
+    public InstantDrainEvent(String type) {
+        this(type, EntityRef.NULL);
+    }
+
+    public InstantDrainEvent(String type, EntityRef instigator) {
+        this.poolType = type;
+        this.instigator = instigator;
+    }
+
+    public EntityRef getInstigator() {
+        return instigator;
+    }
+}

--- a/src/main/java/org/terasology/PointPool/event/InstantDrainEvent.java
+++ b/src/main/java/org/terasology/PointPool/event/InstantDrainEvent.java
@@ -18,6 +18,9 @@ package org.terasology.PointPool.event;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
 
+/**
+ * Event sent to completely drain the pool with given poolType
+ */
 public class InstantDrainEvent implements Event {
 
     String poolType = "";

--- a/src/main/java/org/terasology/PointPool/event/InstantFillEvent.java
+++ b/src/main/java/org/terasology/PointPool/event/InstantFillEvent.java
@@ -18,6 +18,9 @@ package org.terasology.PointPool.event;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
 
+/**
+ * Event sent to completely fill the pool of given poolType
+ */
 public class InstantFillEvent implements Event {
 
     String poolType = "";

--- a/src/main/java/org/terasology/PointPool/event/InstantFillEvent.java
+++ b/src/main/java/org/terasology/PointPool/event/InstantFillEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.PointPool.event;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+
+public class InstantFillEvent implements Event {
+
+    String poolType = "";
+    private EntityRef instigator;
+
+    public InstantFillEvent(String type) {
+        this(type, EntityRef.NULL);
+    }
+
+    public InstantFillEvent(String type, EntityRef instigator) {
+        this.poolType = type;
+        this.instigator = instigator;
+    }
+
+    public EntityRef getInstigator() {
+        return instigator;
+    }
+}


### PR DESCRIPTION
Added fillPool, drainPool, instantDrain, instantFill commands for PointPool

How to test (fillPool):
1. Console command `poolStatus Test`, which should print the current value of the pool
2. Console command `fillPool <amount>`.
3. Console command `poolStatus Test`, which should print new value of pool
If the entered amount makes the poolValue greater than maxPoolValue, it will become maxPoolValue

How to test (drainPool):
1. Console command `poolStatus Test`, which should print the current value of the pool
2. Console command `drainPool <amount>`.
3. Console command `poolStatus Test`, which should decrease the pool value by amount
If the entered amount makes the poolValue negative, it will become 0.0

How to test (instantFill):
1. Console command `poolStatus Test`, which should print the current value of the pool
2. Console command `instantFill Test`.
3. Console command `poolStatus Test`, which should print maxvalue of pool (100.0)

How to test (instantDrain):
1. Console command `poolStatus Test`, which should print the current value of the pool
2. Console command `instantDrain Test`.
3. Console command `poolStatus Test`, which should print min value of pool (0.0)

Outstanding work:
- To add multiple pool components
- Test these commands on individual pool when multiple pools are present